### PR TITLE
update jenkins packages  installation command & docker-ce

### DIFF
--- a/instalaciones/docker/Dockerfile
+++ b/instalaciones/docker/Dockerfile
@@ -4,19 +4,18 @@ FROM jenkins/jenkins:lts
  #docker run  -p "80:8080" jenkins
 USER root
 #si sabes trabajar con los plugin usa el comando siguiente
-RUN /usr/local/bin/install-plugins.sh \  
-   docker-workflow:1.26
-#   dashboard-view:2.9.10 \  
-#   pipeline-stage-view:2.4 \  
-#   parameterized-trigger:2.32 \  
-#   bitbucket:1.1.5 \  
-#   git:3.0.5 \  
-#   github:1.26.0 \
-#   sonarqube-generic-coverage:1.0 \
-#   ssh-slaves:1.31.0 \
-#   ec2-fleet:1.17.0 \
-#   configuration-as-code-groovy:1.1 \
-#   pipeline-maven:3.8.2
+RUN jenkins-plugin-cli --plugins docker-workflow:1.26 \
+dashboard-view:2.9.10 \  
+pipeline-stage-view:2.4 \  
+parameterized-trigger:2.43.1 \  
+bitbucket:1.1.5 \  
+git:5.1.0 \  
+github:1.26.0 \
+sonarqube-generic-coverage:1.0 \
+ssh-slaves:1.31.0 \
+ec2-fleet:1.17.0 \
+configuration-as-code-groovy:1.1 \
+pipeline-maven:3.8.2
 
 RUN apt-get update -qq \
     && apt-get install -qqy apt-transport-https ca-certificates curl gnupg2 software-properties-common 
@@ -26,7 +25,7 @@ RUN add-apt-repository \
    $(lsb_release -cs) \
    stable"
 RUN apt-get update  -qq \
-    && apt-get install docker-ce=17.12.1~ce-0~debian -y
+    && apt-get install docker-ce -y
 
 
 #RUN apt install maven -y


### PR DESCRIPTION
I tried to install jenkins by using this Dockerfile but I couldn't, it looks like `/usr/local/bin/install-plugins.sh` is already deprecated

Error I got:

```
 => CACHED [ 1/14] FROM docker.io/jenkins/jenkins:lts                                                                                                     0.0s
 => ERROR [ 2/14] RUN /usr/local/bin/install-plugins.sh    docker-workflow:1.26                                                                           0.5s
------
 > [ 2/14] RUN /usr/local/bin/install-plugins.sh    docker-workflow:1.26:
#0 0.442 WARN: install-plugins.sh has been removed, please switch to jenkins-plugin-cli
```
Also I had some issues with the docker installation

```
#0 2.426 Reading state information...
#0 2.480 E: Version '17.12.1~ce-0~debian' for 'docker-ce' was not found
```
Pushed the fixes so that other people can use this and follow the course